### PR TITLE
MobileNetV1とMobileNetV2のモデル差し替え

### DIFF
--- a/image_classification/mobilenetv1/README.md
+++ b/image_classification/mobilenetv1/README.md
@@ -53,5 +53,6 @@ TensorFlow 2.4.1, 1.15
 
 ### Netron
 
+- [mobilenetv1_quant_recalib.tflite](https://netron.app/?url=https://storage.googleapis.com/ailia-models-tflite/mobilenetv1/mobilenetv1_quant_recalib.tflite)
 - [mobilenetv1_quant.tflite](https://netron.app/?url=https://storage.googleapis.com/ailia-models-tflite/mobilenetv1/mobilenetv1_quant.tflite)
 - [mobilenetv1_float.tflite](https://netron.app/?url=https://storage.googleapis.com/ailia-models-tflite/mobilenetv1/mobilenetv1_float.tflite)

--- a/image_classification/mobilenetv1/mobilenetv1.py
+++ b/image_classification/mobilenetv1/mobilenetv1.py
@@ -40,9 +40,9 @@ parser.add_argument(
     help='Flag to output the prediction file.'
 )
 parser.add_argument(
-    '--recalib',
+    '--legacy',
     action='store_true',
-    help='Use re-calibrated model. The default model was calibrated by only 4 images. If you specify recalib option, we use 50000 images for calibaraion.'
+    help='Use legacy model. The default model was re-calibrated by 50000 images. If you specify legacy option, we use only 4 images for calibaraion.'
 )
 parser.add_argument(
     '--tta', '-t', metavar='TTA',
@@ -67,10 +67,10 @@ if args.shape:
 if args.float:
     MODEL_NAME = 'mobilenetv1_float'
 else:
-    if args.recalib:
-        MODEL_NAME = 'mobilenetv1_quant_recalib'
-    else:
+    if args.legacy:
         MODEL_NAME = 'mobilenetv1_quant'
+    else:
+        MODEL_NAME = 'mobilenetv1_quant_recalib'
 MODEL_PATH = f'{MODEL_NAME}.tflite'
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/mobilenetv1/'
 

--- a/image_classification/mobilenetv1/mobilenetv1.py
+++ b/image_classification/mobilenetv1/mobilenetv1.py
@@ -145,7 +145,7 @@ def recognize_from_image():
         if args.write_prediction:
             savepath = get_savepath(args.savepath, image_path)
             pred_file = '%s.txt' % savepath.rsplit('.', 1)[0]
-            write_predictions(pred_file, preds_tf_lite, mobilenetv2_labels.imagenet_category)
+            write_predictions(pred_file, preds_tf_lite, mobilenetv1_labels.imagenet_category)
 
         if args.profile:
             print(interpreter.get_summary())

--- a/image_classification/mobilenetv1/mobilenetv1.py
+++ b/image_classification/mobilenetv1/mobilenetv1.py
@@ -8,10 +8,10 @@ import mobilenetv1_labels
 
 # import original modules
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser  # noqa: E402
-from model_utils import check_and_download_models, format_input_tensor  # noqa: E402
+from utils import get_base_parser, update_parser, get_savepath  # noqa: E402
+from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
-from classifier_utils import plot_results, print_results  # noqa: E402
+from classifier_utils import plot_results, print_results, write_predictions  # noqa: E402
 import webcamera_utils  # noqa: E402
 
 
@@ -25,12 +25,30 @@ IMAGE_WIDTH = 224
 MAX_CLASS_COUNT = 3
 SLEEP_TIME = 0
 
+TTA_NAMES = ['none', '1_crop']
+
 
 # ======================
 # Argument Parser Config
 # ======================
 parser = get_base_parser(
     'ImageNet classification Model', IMAGE_PATH, None
+)
+parser.add_argument(
+    '-w', '--write_prediction',
+    action='store_true',
+    help='Flag to output the prediction file.'
+)
+parser.add_argument(
+    '--recalib',
+    action='store_true',
+    help='Use re-calibrated model. The default model was calibrated by only 4 images. If you specify recalib option, we use 50000 images for calibaraion.'
+)
+parser.add_argument(
+    '--tta', '-t', metavar='TTA',
+    default='none', choices=TTA_NAMES,
+    help=('tta scheme: ' + ' | '.join(TTA_NAMES) +
+          ' (default: none)')
 )
 args = update_parser(parser)
 
@@ -49,7 +67,10 @@ if args.shape:
 if args.float:
     MODEL_NAME = 'mobilenetv1_float'
 else:
-    MODEL_NAME = 'mobilenetv1_quant'
+    if args.recalib:
+        MODEL_NAME = 'mobilenetv1_quant_recalib'
+    else:
+        MODEL_NAME = 'mobilenetv1_quant'
 MODEL_PATH = f'{MODEL_NAME}.tflite'
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/mobilenetv1/'
 
@@ -66,6 +87,8 @@ def recognize_from_image():
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags)
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
+    if args.profile:
+        interpreter.set_profile_mode(True)
     interpreter.allocate_tensors()
     input_details = interpreter.get_input_details()
     output_details = interpreter.get_output_details()
@@ -87,8 +110,9 @@ def recognize_from_image():
             (IMAGE_HEIGHT, IMAGE_WIDTH),
             normalize_type='None',
             gen_input_ailia_tflite=True,
-            bgr_to_rgb=False,
-            output_type=dtype
+            bgr_to_rgb=True,
+            output_type=dtype,
+            tta=args.tta
         )
         input_data = input_data / 127.5 - 1
 
@@ -103,7 +127,7 @@ def recognize_from_image():
                 start = int(round(time.time() * 1000))
                 interpreter.set_tensor(input_details[0]['index'], input_data)
                 interpreter.invoke()
-                preds_tf_lite = interpreter.get_tensor(output_details[0]['index'])
+                preds_tf_lite = get_output_tensor(interpreter, output_details, 0)
                 end = int(round(time.time() * 1000))
                 average_time = average_time + (end - start)
                 print(f'\tailia processing time {end - start} ms')
@@ -111,9 +135,21 @@ def recognize_from_image():
         else:
             interpreter.set_tensor(input_details[0]['index'], input_data)
             interpreter.invoke()
-            preds_tf_lite = interpreter.get_tensor(output_details[0]['index'])
+            preds_tf_lite = get_output_tensor(interpreter, output_details, 0)
 
-        print_results(preds_tf_lite, mobilenetv1_labels.imagenet_category)
+        preds_tf_lite_int8 = interpreter.get_tensor(output_details[0]['index'])
+
+        print_results([preds_tf_lite[0], preds_tf_lite_int8[0]], mobilenetv1_labels.imagenet_category)
+
+        # write prediction
+        if args.write_prediction:
+            savepath = get_savepath(args.savepath, image_path)
+            pred_file = '%s.txt' % savepath.rsplit('.', 1)[0]
+            write_predictions(pred_file, preds_tf_lite, mobilenetv2_labels.imagenet_category)
+
+        if args.profile:
+            print(interpreter.get_summary())
+
     print('Script finished successfully.')
 
 
@@ -154,7 +190,7 @@ def recognize_from_video():
 
         input_image, input_data = webcamera_utils.preprocess_frame(
             frame, IMAGE_HEIGHT, IMAGE_WIDTH, normalize_type='None',
-            bgr_to_rgb=False, output_type=dtype
+            bgr_to_rgb=True, output_type=dtype
         )
         input_data = input_data / 127.5 - 1
 

--- a/image_classification/mobilenetv2/README.md
+++ b/image_classification/mobilenetv2/README.md
@@ -53,5 +53,6 @@ TensorFlow 2.4.1, 1.15
 
 ### Netron
 
+- [mobilenetv2_quant_recalib.tflite](https://netron.app/?url=https://storage.googleapis.com/ailia-models-tflite/mobilenetv2/mobilenetv2_quant_recalib.tflite)
 - [mobilenetv2_quant.tflite](https://netron.app/?url=https://storage.googleapis.com/ailia-models-tflite/mobilenetv2/mobilenetv2_quant.tflite)
 - [mobilenetv2_float.tflite](https://netron.app/?url=https://storage.googleapis.com/ailia-models-tflite/mobilenetv2/mobilenetv2_float.tflite)

--- a/image_classification/mobilenetv2/mobilenetv2.py
+++ b/image_classification/mobilenetv2/mobilenetv2.py
@@ -102,7 +102,7 @@ def recognize_from_image():
 
     for image_path in args.input:
         # prepare input data
-        dtype = np.int8
+        dtype = np.uint8
         if args.float:
             dtype = np.float32
         input_data = load_image(
@@ -181,7 +181,7 @@ def recognize_from_video():
     else:
         writer = None
 
-    dtype = np.int8
+    dtype = np.uint8
     if args.float or not args.legacy:
         dtype = np.float32
 

--- a/image_classification/mobilenetv2/mobilenetv2.py
+++ b/image_classification/mobilenetv2/mobilenetv2.py
@@ -40,9 +40,9 @@ parser.add_argument(
     help='Flag to output the prediction file.'
 )
 parser.add_argument(
-    '--recalib',
+    '--legacy',
     action='store_true',
-    help='Use re-calibrated model. The default model was calibrated by only 4 images. If you specify recalib option, we use 50000 images for calibaraion.'
+    help='Use legacy model. The default model was re-calibrated by 50000 images. If you specify legacy option, we use only 4 images for calibaraion.'
 )
 parser.add_argument(
     '--tta', '-t', metavar='TTA',
@@ -67,10 +67,10 @@ if args.shape:
 if args.float:
     MODEL_NAME = 'mobilenetv2_float'
 else:
-    if args.recalib:
-        MODEL_NAME = 'mobilenetv2_quant_recalib'
-    else:
+    if args.legacy:
         MODEL_NAME = 'mobilenetv2_quant'
+    else:
+        MODEL_NAME = 'mobilenetv2_quant_recalib'
 MODEL_PATH = f'{MODEL_NAME}.tflite'
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/mobilenetv2/'
 
@@ -115,7 +115,7 @@ def recognize_from_image():
             tta=args.tta
         )
 
-        if args.float or args.recalib:
+        if args.float or not args.legacy:
             input_data = input_data / 127.5 - 1
 
         # quantize input data
@@ -182,7 +182,7 @@ def recognize_from_video():
         writer = None
 
     dtype = np.int8
-    if args.float or args.recalib:
+    if args.float or not args.legacy:
         dtype = np.float32
 
     while(True):

--- a/image_classification/resnet50/README.md
+++ b/image_classification/resnet50/README.md
@@ -54,5 +54,6 @@ TensorFlow 2.6
 
 ### Netron
 
+- [resnet50_quant_recalib.tflite](https://netron.app/?url=https://storage.googleapis.com/ailia-models-tflite/resnet50/resnet50_quant_recalib.tflite)
 - [resnet50_quant.tflite](https://netron.app/?url=https://storage.googleapis.com/ailia-models-tflite/resnet50/resnet50_quant.tflite)
 - [resnet50_float.tflite](https://netron.app/?url=https://storage.googleapis.com/ailia-models-tflite/resnet50/resnet50_float.tflite)

--- a/image_classification/resnet50/resnet50.py
+++ b/image_classification/resnet50/resnet50.py
@@ -88,6 +88,8 @@ def recognize_from_image():
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags)
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
+    if args.profile:
+        interpreter.set_profile_mode(True)
     interpreter.allocate_tensors()
     input_details = interpreter.get_input_details()
     output_details = interpreter.get_output_details()
@@ -151,6 +153,9 @@ def recognize_from_image():
             savepath = get_savepath(args.savepath, image_path)
             pred_file = '%s.txt' % savepath.rsplit('.', 1)[0]
             write_predictions(pred_file, preds_tf_lite, resnet50_labels.imagenet_category)
+
+        if args.profile:
+            print(interpreter.get_summary())
 
     print('Script finished successfully.')
 

--- a/image_classification/resnet50/resnet50.py
+++ b/image_classification/resnet50/resnet50.py
@@ -41,9 +41,9 @@ parser.add_argument(
     help='Flag to output the prediction file.'
 )
 parser.add_argument(
-    '--recalib',
+    '--legacy',
     action='store_true',
-    help='Use re-calibrated model. The default model was calibrated by only 4 images. If you specify recalib option, we use 50000 images for calibaraion.'
+    help='Use legacy model. The default model was re-calibrated by 50000 images. If you specify legacy option, we use only 4 images for calibaraion.'
 )
 parser.add_argument(
     '--tta', '-t', metavar='TTA',
@@ -68,10 +68,10 @@ if args.shape:
 if args.float:
     MODEL_NAME = 'resnet50_float'
 else:
-    if args.recalib:
-        MODEL_NAME = 'resnet50_quant_recalib'
-    else:
+    if args.legacy:
         MODEL_NAME = 'resnet50_quant'
+    else:
+        MODEL_NAME = 'resnet50_quant_recalib'
 MODEL_PATH = f'{MODEL_NAME}.tflite'
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/resnet50/'
 


### PR DESCRIPTION
--recalibオプションでImageNetのValidationセットを使用してInt8で量子化したモデルを使用する機能を追加。
また、MobileNetV1とV2で使用されている
　imagenet_utils.preprocess_input(x, data_format=data_format, mode="tf")
はRGBを処理対象とするが、BGRで処理していた問題を修正。