### PR TITLE
env_id対応、External-Delegate対応

### DIFF
--- a/background_removal/u2net/u2net.py
+++ b/background_removal/u2net/u2net.py
@@ -11,7 +11,7 @@ from logging import getLogger  # noqa: E402
 
 import webcamera_utils  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor  # noqa: E402
-from utils import get_base_parser, get_savepath, update_parser  # noqa: E402
+from utils import get_base_parser, get_savepath, update_parser, delegate_obj  # noqa: E402
 
 from u2net_utils import imread, load_image, norm, save_result, transform  # noqa: E402
 
@@ -206,8 +206,8 @@ def main():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     

--- a/depth_estimation/midas/midas.py
+++ b/depth_estimation/midas/midas.py
@@ -12,7 +12,7 @@ from logging import getLogger  # noqa: E402
 
 from image_utils import resize_image, load_image, normalize_image  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor #★  # noqa: E402
-from utils import get_base_parser, get_savepath, update_parser  # noqa: E402
+from utils import get_base_parser, get_savepath, update_parser, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer, preprocess_frame  # noqa: E402
 
 logger = getLogger(__name__)
@@ -265,8 +265,8 @@ def main():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     if args.profile:

--- a/face_detection/blazeface/blazeface.py
+++ b/face_detection/blazeface/blazeface.py
@@ -8,7 +8,7 @@ import blazeface_utils as but
 
 # import original modules
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath  # noqa: E402
+from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from image_utils import load_image  # noqa: E402
 import webcamera_utils  # noqa: E402
@@ -62,8 +62,8 @@ def recognize_from_image():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     interpreter.allocate_tensors()

--- a/face_recognition/face_classification/face_classification.py
+++ b/face_recognition/face_classification/face_classification.py
@@ -15,7 +15,7 @@ from logging import getLogger  # noqa: E402
 import webcamera_utils  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
-from utils import get_base_parser, update_parser  # noqa: E402
+from utils import get_base_parser, update_parser, delegate_obj  # noqa: E402
 
 logger = getLogger(__name__)
 
@@ -390,8 +390,8 @@ def main():
     if args.tflite:
         interpreter_emo = tf.lite.Interpreter(model_path=EMOTION_MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter_emo = ailia_tflite.Interpreter(model_path=EMOTION_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter_emo = ailia_tflite.Interpreter(model_path=EMOTION_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter_emo = ailia_tflite.Interpreter(model_path=EMOTION_MODEL_PATH)
     if args.profile:
@@ -402,8 +402,8 @@ def main():
     if args.tflite:
         interpreter_gen = tf.lite.Interpreter(model_path=GENDER_MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter_gen = ailia_tflite.Interpreter(model_path=GENDER_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter_gen = ailia_tflite.Interpreter(model_path=GENDER_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter_gen = ailia_tflite.Interpreter(model_path=GENDER_MODEL_PATH)
     if args.profile:

--- a/face_recognition/facemesh/facemesh.py
+++ b/face_recognition/facemesh/facemesh.py
@@ -8,7 +8,7 @@ from scipy.special import expit
 import facemesh_utils as fut
 
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath  # noqa: E402
+from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer  # noqa: E402
 from image_utils import load_image, preprocess_image  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
@@ -125,9 +125,9 @@ def recognize_from_image():
         detector = tf.lite.Interpreter(model_path=DETECTOR_MODEL_PATH)
         estimator = tf.lite.Interpreter(model_path=LANDMARK_MODEL_PATH)
     else:
-        if args.memory_mode or args.flags or args.env_id:
-            detector = ailia_tflite.Interpreter(model_path=DETECTOR_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
-            estimator = ailia_tflite.Interpreter(model_path=LANDMARK_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.memory_mode or args.flags or args.env_id or args.delegate_path is not None:
+            detector = ailia_tflite.Interpreter(model_path=DETECTOR_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
+            estimator = ailia_tflite.Interpreter(model_path=LANDMARK_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             detector = ailia_tflite.Interpreter(model_path=DETECTOR_MODEL_PATH)
             estimator = ailia_tflite.Interpreter(model_path=LANDMARK_MODEL_PATH)

--- a/hand_recognition/blazehand/blazehand.py
+++ b/hand_recognition/blazehand/blazehand.py
@@ -7,7 +7,7 @@ import numpy as np
 import blazehand_utils as but
 
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath  # noqa: E402
+from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer  # noqa: E402
 from image_utils import load_image, preprocess_image  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
@@ -368,9 +368,9 @@ def main():
         detector = tf.lite.Interpreter(model_path=DETECTOR_MODEL_PATH)
         estimator = tf.lite.Interpreter(model_path=LANDMARK_MODEL_PATH)
     else:
-        if args.memory_mode or args.flags or args.env_id:
-            detector = ailia_tflite.Interpreter(model_path=DETECTOR_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
-            estimator = ailia_tflite.Interpreter(model_path=LANDMARK_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.memory_mode or args.flags or args.env_id or args.delegate_path is not None:
+            detector = ailia_tflite.Interpreter(model_path=DETECTOR_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
+            estimator = ailia_tflite.Interpreter(model_path=LANDMARK_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             detector = ailia_tflite.Interpreter(model_path=DETECTOR_MODEL_PATH)
             estimator = ailia_tflite.Interpreter(model_path=LANDMARK_MODEL_PATH)

--- a/image_classification/efficientnet_lite/efficientnet_lite.py
+++ b/image_classification/efficientnet_lite/efficientnet_lite.py
@@ -9,7 +9,7 @@ import efficientnet_lite_labels
 
 # import original modules
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath  # noqa: E402
+from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results, write_predictions  # noqa: E402
@@ -106,8 +106,8 @@ def recognize_from_image():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     if args.profile:

--- a/image_classification/googlenet/googlenet.py
+++ b/image_classification/googlenet/googlenet.py
@@ -8,7 +8,7 @@ import googlenet_labels
 
 # import original modules
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser  # noqa: E402
+from utils import get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results  # noqa: E402
@@ -179,8 +179,8 @@ def main():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     if args.profile:

--- a/image_classification/mobilenetv1/mobilenetv1.py
+++ b/image_classification/mobilenetv1/mobilenetv1.py
@@ -8,7 +8,7 @@ import mobilenetv1_labels
 
 # import original modules
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath  # noqa: E402
+from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results, write_predictions  # noqa: E402
@@ -83,8 +83,8 @@ def recognize_from_image():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     if args.profile:

--- a/image_classification/mobilenetv2/mobilenetv2.py
+++ b/image_classification/mobilenetv2/mobilenetv2.py
@@ -8,7 +8,7 @@ import mobilenetv2_labels
 
 # import original modules
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath  # noqa: E402
+from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results, write_predictions  # noqa: E402
@@ -83,8 +83,8 @@ def recognize_from_image():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     if args.profile:

--- a/image_classification/resnet50/resnet50.py
+++ b/image_classification/resnet50/resnet50.py
@@ -9,7 +9,7 @@ import resnet50_labels
 
 # import original modules
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath  # noqa: E402
+from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results, write_predictions  # noqa: E402
@@ -84,8 +84,8 @@ def recognize_from_image():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     if args.profile:

--- a/image_classification/squeezenet/squeezenet.py
+++ b/image_classification/squeezenet/squeezenet.py
@@ -8,7 +8,7 @@ import squeezenet_labels
 
 # import original modules
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser  # noqa: E402
+from utils import get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results  # noqa: E402
@@ -75,8 +75,8 @@ def recognize_from_image():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     interpreter.allocate_tensors()

--- a/image_classification/vgg16/vgg16.py
+++ b/image_classification/vgg16/vgg16.py
@@ -8,7 +8,7 @@ import vgg16_labels
 
 # import original modules
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser  # noqa: E402
+from utils import get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results  # noqa: E402
@@ -174,8 +174,8 @@ def main():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     if args.profile:

--- a/image_segmentation/deeplabv3plus/deeplabv3plus.py
+++ b/image_segmentation/deeplabv3plus/deeplabv3plus.py
@@ -8,7 +8,7 @@ from deeplab_utils import *
 
 # import original modules
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath  # noqa: E402
+from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results  # noqa: E402
@@ -66,8 +66,8 @@ def segment_from_image():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     interpreter.allocate_tensors()

--- a/image_segmentation/hrnet_segmentation/hrnet_segmentation.py
+++ b/image_segmentation/hrnet_segmentation/hrnet_segmentation.py
@@ -7,7 +7,7 @@ from hrnet_utils import smooth_output, save_pred, gen_preds_img_np
 
 
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath  # noqa: E402
+from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor  # noqa: E402
 from image_utils import load_image, preprocess_image  # noqa: E402
 import webcamera_utils  # noqa: E402
@@ -82,12 +82,13 @@ def recognize_from_image():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id or args.env_id:
+        if args.flags or args.memory_mode or args.env_id or args.env_id or args.delegate_path is not None:
             interpreter = ailia_tflite.Interpreter(
                 model_path=MODEL_PATH, 
                 memory_mode=args.memory_mode, 
                 flags=args.flags,
-                env_id = args.env_id
+                env_id = args.env_id,
+                experimental_delegates = delegate_obj(args.delegate_path)
             )
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)

--- a/image_segmentation/hrnet_segmentation/hrnet_segmentation.py
+++ b/image_segmentation/hrnet_segmentation/hrnet_segmentation.py
@@ -82,11 +82,12 @@ def recognize_from_image():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
+        if args.flags or args.memory_mode or args.env_id or args.env_id:
             interpreter = ailia_tflite.Interpreter(
                 model_path=MODEL_PATH, 
                 memory_mode=args.memory_mode, 
-                flags=args.flags
+                flags=args.flags,
+                env_id = args.env_id
             )
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)

--- a/object_detection/efficientdet_lite/efficientdet_lite.py
+++ b/object_detection/efficientdet_lite/efficientdet_lite.py
@@ -7,7 +7,7 @@ import cv2
 import numpy as np
 
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser  # noqa: E402
+from utils import get_base_parser, update_parser, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer  # noqa: E402
 from image_utils import load_image, preprocess_image  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
@@ -193,8 +193,8 @@ def recognize_from_image():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     interpreter.allocate_tensors()

--- a/object_detection/mobilenetssd/mobilenetv2ssdlite.py
+++ b/object_detection/mobilenetssd/mobilenetv2ssdlite.py
@@ -7,7 +7,7 @@ import mobilenetv2ssdlite_utils as mut
 
 # import original modules
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser  # noqa: E402
+from utils import get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from detector_utils import plot_results  # noqa: E402
@@ -59,8 +59,8 @@ def recognize_from_image():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     try:

--- a/object_detection/yolov3-tiny/yolov3-tiny.py
+++ b/object_detection/yolov3-tiny/yolov3-tiny.py
@@ -7,7 +7,7 @@ import cv2
 import numpy as np
 
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath  # noqa: E402
+from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer  # noqa: E402
 from image_utils import load_image, preprocess_image  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
@@ -187,8 +187,8 @@ def recognize_from_image():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     interpreter.allocate_tensors()

--- a/object_detection/yolox/yolox.py
+++ b/object_detection/yolox/yolox.py
@@ -10,7 +10,7 @@ from yolox_utils import postprocess, filter_predictions
 
 # import original modules
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath
+from utils import get_base_parser, update_parser, get_savepath, delegate_obj
 from model_utils import check_and_download_models, format_input_tensor, \
     get_output_tensor
 from detector_utils import plot_results, write_predictions
@@ -138,8 +138,8 @@ def recognize_from_image():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     interpreter.allocate_tensors()

--- a/pose_estimation/pose_resnet/pose_resnet.py
+++ b/pose_estimation/pose_resnet/pose_resnet.py
@@ -8,7 +8,7 @@ import const
 
 # import original modules
 sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath  # noqa: E402
+from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from image_utils import load_image as load_image_img, preprocess_image  # noqa: E402
 from detector_utils import load_image as load_image_det  # noqa: E402
@@ -460,8 +460,8 @@ def main():
     if args.tflite:
         interpreter_pose = tf.lite.Interpreter(model_path=POSE_MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter_pose = ailia_tflite.Interpreter(model_path=POSE_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter_pose = ailia_tflite.Interpreter(model_path=POSE_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter_pose = ailia_tflite.Interpreter(model_path=POSE_MODEL_PATH)
     interpreter_pose.allocate_tensors()
@@ -470,8 +470,8 @@ def main():
     if args.tflite:
         interpreter_detect = tf.lite.Interpreter(model_path=DETECT_MODEL_PATH)
     else:
-        if args.flags or args.memory_mode or args.env_id:
-            interpreter_detect = ailia_tflite.Interpreter(model_path=DETECT_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter_detect = ailia_tflite.Interpreter(model_path=DETECT_MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter_detect = ailia_tflite.Interpreter(model_path=DETECT_MODEL_PATH)
     interpreter_detect.allocate_tensors()

--- a/super_resolution/srresnet/srresnet.py
+++ b/super_resolution/srresnet/srresnet.py
@@ -13,7 +13,7 @@ from logging import getLogger  # noqa: E402
 import webcamera_utils  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
-from utils import get_base_parser, get_savepath, update_parser  # noqa: E402
+from utils import get_base_parser, get_savepath, update_parser, delegate_obj  # noqa: E402
 
 logger = getLogger(__name__)
 
@@ -259,8 +259,8 @@ def main():
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
-        if args.flags or args.memory_mode:
-            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags)
+        if args.flags or args.memory_mode or args.env_id or args.delegate_path is not None:
+            interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH, memory_mode = args.memory_mode, flags = args.flags, env_id = args.env_id, experimental_delegates = delegate_obj(args.delegate_path))
         else:
             interpreter = ailia_tflite.Interpreter(model_path=MODEL_PATH)
     if args.profile:

--- a/util/utils.py
+++ b/util/utils.py
@@ -125,7 +125,7 @@ def get_base_parser(
     )
     parser.add_argument(
         '-e', '--env_id', type=int, default=0,
-        help='set environment id. 0 = CPU, 1 = NNAPI, 2 = MMALIB, 3 = MMALIB_COMPATIBLE, 4 = QNN'
+        help='set environment id. 0 = CPU, 1 = NNAPI, 2 = MMALIB, 3 = MMALIB_COMPATIBLE, 4 = QNN, 5 = DELEGATE'
     )
     parser.add_argument(
         '-cw', '--camera_width',
@@ -136,6 +136,10 @@ def get_base_parser(
         '-ch', '--camera_height',
         default=0, type=int,
         help='set camera height'
+    )
+    parser.add_argument(
+        '--delegate_path', type=str, default=None,
+        help='external delegate file path'
     )
     return parser
 
@@ -241,3 +245,9 @@ def get_savepath(arg_path, src_path, prefix='', post_fix='_res', ext=None):
             arg_path, prefix + src_base + post_fix + new_ext
         )
     return new_path
+
+def delegate_obj(delegate_path):
+    if delegate_path is None:
+        return None
+    else:
+        return [ailia_tflite.load_delegate(delegate_path)]


### PR DESCRIPTION
* env_id (コマンド引数 -e) に対応していないメインスクリプト（hrnet_segmentation, srresnet, googlenet）を、対応。
* External-Delegateのパス指定に対応するために、コマンド引数 --delegate <パス> で指定できるよう、全メインスクリプトを修正。
Interpreter()の引数 experimental_delegates に、Delegateオブジェクトを渡す形です。

注意：
Interpreter()が引数 experimental_delegates に対応している必要があるため、
本PRの動作には、\_\_init__.py が修正された ailia_tflite (Delegate対応版) が必要です。