### PR TITLE
Quality of life improvement regarding running the examples from any location (no need to cd to model folder)

### DIFF
--- a/background_removal/u2net/u2net.py
+++ b/background_removal/u2net/u2net.py
@@ -5,13 +5,15 @@ import cv2
 import numpy as np
 
 # import original modules
-sys.path.append('../../util')
-# logger
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
 from logging import getLogger  # noqa: E402
 
 import webcamera_utils  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor  # noqa: E402
-from utils import get_base_parser, get_savepath, update_parser, delegate_obj  # noqa: E402
+from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 
 from u2net_utils import imread, load_image, norm, save_result, transform  # noqa: E402
 
@@ -84,7 +86,8 @@ if args.opset == '10':
     MODEL_PATH = f'{model_size}_{model_param}.tflite'
 else:
     MODEL_PATH = f'{model_size}_opset11_{model_param}.tflite'
-    
+
+MODEL_PATH = file_abs_path(__file__, MODEL_PATH)
 REMOTE_PATH = 'https://storage.googleapis.com/ailia-models-tflite/u2net/'
 
 

--- a/background_removal/u2net/u2net.py
+++ b/background_removal/u2net/u2net.py
@@ -1,26 +1,28 @@
+import os
 import sys
-import time
+from logging import getLogger  # noqa: E402
 
 import cv2
 import numpy as np
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
-from logging import getLogger  # noqa: E402
+
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
 
 import webcamera_utils  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor  # noqa: E402
 from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
-
 from u2net_utils import imread, load_image, norm, save_result, transform  # noqa: E402
+
 
 logger = getLogger(__name__)
 

--- a/background_removal/u2net/u2net.py
+++ b/background_removal/u2net/u2net.py
@@ -8,9 +8,9 @@ import numpy as np
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/background_removal/u2net/u2net.py
+++ b/background_removal/u2net/u2net.py
@@ -6,8 +6,13 @@ import numpy as np
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from logging import getLogger  # noqa: E402
 

--- a/background_removal/u2net/u2net_utils.py
+++ b/background_removal/u2net/u2net_utils.py
@@ -5,8 +5,13 @@ import cv2
 import numpy as np
 
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from logging import getLogger  # noqa: E402
 

--- a/background_removal/u2net/u2net_utils.py
+++ b/background_removal/u2net/u2net_utils.py
@@ -4,15 +4,6 @@ import os
 import cv2
 import numpy as np
 
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
 from logging import getLogger  # noqa: E402
 
 logger = getLogger(__name__)

--- a/background_removal/u2net/u2net_utils.py
+++ b/background_removal/u2net/u2net_utils.py
@@ -7,9 +7,9 @@ import numpy as np
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/background_removal/u2net/u2net_utils.py
+++ b/background_removal/u2net/u2net_utils.py
@@ -4,8 +4,10 @@ import os
 import cv2
 import numpy as np
 
-sys.path.append('../../util')
-# logger
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
 from logging import getLogger  # noqa: E402
 
 logger = getLogger(__name__)

--- a/depth_estimation/midas/midas.py
+++ b/depth_estimation/midas/midas.py
@@ -1,26 +1,28 @@
 import os
 import sys
-import time
+from logging import getLogger  # noqa: E402
 
 import cv2
 import numpy as np
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
-from logging import getLogger  # noqa: E402
+
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
 
 from image_utils import resize_image, load_image  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor # noqa: E402
 from utils import file_abs_path, get_base_parser, get_savepath, update_parser, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer, preprocess_frame  # noqa: E402
+
 
 logger = getLogger(__name__)
 

--- a/depth_estimation/midas/midas.py
+++ b/depth_estimation/midas/midas.py
@@ -6,13 +6,15 @@ import cv2
 import numpy as np
 
 # import original modules
-sys.path.append('../../util')
-# logger
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
 from logging import getLogger  # noqa: E402
 
-from image_utils import resize_image, load_image, normalize_image  # noqa: E402
-from model_utils import check_and_download_models, format_input_tensor, get_output_tensor #★  # noqa: E402
-from utils import get_base_parser, get_savepath, update_parser, delegate_obj  # noqa: E402
+from image_utils import resize_image, load_image  # noqa: E402
+from model_utils import check_and_download_models, format_input_tensor, get_output_tensor # noqa: E402
+from utils import file_abs_path, get_base_parser, get_savepath, update_parser, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer, preprocess_frame  # noqa: E402
 
 logger = getLogger(__name__)
@@ -69,8 +71,7 @@ else:
         MODEL_NAME = 'midas_v2.1_small_quant_recalib'
     if not args.v21:
         MODEL_NAME = 'midas_quant_recalib'
-MODEL_PATH = f'{MODEL_NAME}.tflite'
-
+MODEL_PATH = file_abs_path(__file__, f'{MODEL_NAME}.tflite')
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/midas/'
 
 

--- a/depth_estimation/midas/midas.py
+++ b/depth_estimation/midas/midas.py
@@ -7,8 +7,13 @@ import numpy as np
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from logging import getLogger  # noqa: E402
 

--- a/depth_estimation/midas/midas.py
+++ b/depth_estimation/midas/midas.py
@@ -9,9 +9,9 @@ import numpy as np
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/face_detection/blazeface/blazeface.py
+++ b/face_detection/blazeface/blazeface.py
@@ -10,9 +10,9 @@ import blazeface_utils as but
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/face_detection/blazeface/blazeface.py
+++ b/face_detection/blazeface/blazeface.py
@@ -118,7 +118,7 @@ def recognize_from_image():
             preds_tf_lite[1] = interpreter.get_tensor(output_details[0]['index'])   #1x896x1 classificators
 
         # postprocessing
-        detections = but.postprocess(preds_tf_lite(__file__, "anchors.npy"))
+        detections = but.postprocess(preds_tf_lite, file_abs_path(__file__, "anchors.npy"))
 
         savepath = get_savepath(args.savepath, image_path)
         logger.info(f'saved at : {savepath}')        

--- a/face_detection/blazeface/blazeface.py
+++ b/face_detection/blazeface/blazeface.py
@@ -8,8 +8,13 @@ import blazeface_utils as but
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402

--- a/face_detection/blazeface/blazeface.py
+++ b/face_detection/blazeface/blazeface.py
@@ -1,27 +1,31 @@
+import os
 import sys
 import time
-import numpy as np
+from logging import getLogger   # noqa: E402
 
 import cv2
 
-import blazeface_utils as but
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from image_utils import load_image  # noqa: E402
 import webcamera_utils  # noqa: E402
+import blazeface_utils as but
 
-from logging import getLogger   # noqa: E402
+
 logger = getLogger(__name__)
 
 # ======================

--- a/face_detection/blazeface/blazeface.py
+++ b/face_detection/blazeface/blazeface.py
@@ -7,13 +7,15 @@ import cv2
 import blazeface_utils as but
 
 # import original modules
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from image_utils import load_image  # noqa: E402
 import webcamera_utils  # noqa: E402
 
-# logger
 from logging import getLogger   # noqa: E402
 logger = getLogger(__name__)
 
@@ -50,15 +52,17 @@ if args.shape:
     IMAGE_HEIGHT = args.shape
     IMAGE_WIDTH = args.shape
 
+if args.float:
+    MODEL_PATH = MODEL_FLOAT_PATH
+else:
+    MODEL_PATH = MODEL_INT_PATH
+MODEL_PATH = file_abs_path(__file__, MODEL_PATH)
+
 # ======================
 # Main functions
 # ======================
 def recognize_from_image():
     # net initialize
-    if args.float:
-        MODEL_PATH = MODEL_FLOAT_PATH
-    else:
-        MODEL_PATH = MODEL_INT_PATH
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
@@ -114,7 +118,7 @@ def recognize_from_image():
             preds_tf_lite[1] = interpreter.get_tensor(output_details[0]['index'])   #1x896x1 classificators
 
         # postprocessing
-        detections = but.postprocess(preds_tf_lite)
+        detections = but.postprocess(preds_tf_lite(__file__, "anchors.npy"))
 
         savepath = get_savepath(args.savepath, image_path)
         logger.info(f'saved at : {savepath}')        
@@ -128,10 +132,6 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    if args.float:
-        MODEL_PATH = "face_detection_front.tflite"
-    else:
-        MODEL_PATH = "face_detection_front_128_full_integer_quant.tflite"
     if args.tflite:
         interpreter = tf.lite.Interpreter(model_path=MODEL_PATH)
     else:
@@ -178,7 +178,7 @@ def recognize_from_video():
             preds_tf_lite[1] = interpreter.get_tensor(output_details[0]['index'])   #1x896x1 classificators
 
         # postprocessing
-        detections = but.postprocess(preds_tf_lite)
+        detections = but.postprocess(preds_tf_lite, file_abs_path(__file__, "anchors.npy"))
         but.show_result(input_image, detections)
         cv2.imshow('frame', input_image)
 
@@ -195,8 +195,7 @@ def recognize_from_video():
 
 def main():
     # model files check and download
-    check_and_download_models(MODEL_FLOAT_PATH, REMOTE_PATH)
-    check_and_download_models(MODEL_INT_PATH, REMOTE_PATH)
+    check_and_download_models(MODEL_PATH, REMOTE_PATH)
 
     if args.video is not None:
         # video mode

--- a/face_recognition/face_classification/face_classification.py
+++ b/face_recognition/face_classification/face_classification.py
@@ -8,14 +8,16 @@ import numpy as np
 import blazeface_utils as but
 
 # import original modules
-sys.path.append('../../util')
-# logger
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
 from logging import getLogger  # noqa: E402
 
 import webcamera_utils  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
-from utils import get_base_parser, update_parser, delegate_obj  # noqa: E402
+from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 
 logger = getLogger(__name__)
 
@@ -72,9 +74,9 @@ else:
     EMOTION_MODEL_NAME = 'emotion_miniXception_quant'
     GENDER_MODEL_NAME = 'gender_miniXception_quant'
     FACE_MODEL_NAME = 'face_detection_front_128_full_integer_quant'
-EMOTION_MODEL_PATH = f'{EMOTION_MODEL_NAME}.tflite'
-GENDER_MODEL_PATH = f'{GENDER_MODEL_NAME}.tflite'
-FACE_MODEL_PATH = f'{FACE_MODEL_NAME}.tflite'
+EMOTION_MODEL_PATH = file_abs_path(__file__, f'{EMOTION_MODEL_NAME}.tflite')
+GENDER_MODEL_PATH = file_abs_path(__file__, f'{GENDER_MODEL_NAME}.tflite')
+FACE_MODEL_PATH = file_abs_path(__file__, f'{FACE_MODEL_NAME}.tflite')
 
 REMOTE_PATH = 'https://storage.googleapis.com/ailia-models-tflite/face_classification/'
 FACE_REMOTE_PATH = 'https://storage.googleapis.com/ailia-models-tflite/blazeface/'
@@ -259,7 +261,7 @@ def recognize_from_video(interpreter_emo, interpreter_gen, interpreter_det):
             preds_tf_lite[1] = interpreter_det.get_tensor(output_details_det[0]['index'])   #1x896x1 classificators
 
         # postprocessing
-        detections = but.postprocess(preds_tf_lite)
+        detections = but.postprocess(preds_tf_lite, file_abs_path(__file__, "anchors.npy"))
 
         for detection in detections:
             for obj in detection:

--- a/face_recognition/face_classification/face_classification.py
+++ b/face_recognition/face_classification/face_classification.py
@@ -11,9 +11,9 @@ import blazeface_utils as but
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/face_recognition/face_classification/face_classification.py
+++ b/face_recognition/face_classification/face_classification.py
@@ -9,8 +9,13 @@ import blazeface_utils as but
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from logging import getLogger  # noqa: E402
 

--- a/face_recognition/face_classification/face_classification.py
+++ b/face_recognition/face_classification/face_classification.py
@@ -1,28 +1,31 @@
 import os
 import sys
 import time
+from logging import getLogger  # noqa: E402
 
 import cv2
 import numpy as np
 
-import blazeface_utils as but
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
-from logging import getLogger  # noqa: E402
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
 
 import webcamera_utils  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
+import blazeface_utils as but
+
 
 logger = getLogger(__name__)
 

--- a/face_recognition/facemesh/facemesh.py
+++ b/face_recognition/facemesh/facemesh.py
@@ -10,9 +10,9 @@ import facemesh_utils as fut
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/face_recognition/facemesh/facemesh.py
+++ b/face_recognition/facemesh/facemesh.py
@@ -8,8 +8,13 @@ from scipy.special import expit
 import facemesh_utils as fut
 
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer  # noqa: E402

--- a/face_recognition/facemesh/facemesh.py
+++ b/face_recognition/facemesh/facemesh.py
@@ -7,14 +7,16 @@ from scipy.special import expit
 
 import facemesh_utils as fut
 
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer  # noqa: E402
 from image_utils import load_image, preprocess_image  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from facemesh_const import FACEMESH_TESSELATION
 
-# logger
 from logging import getLogger   # noqa: E402
 logger = getLogger(__name__)
 
@@ -58,6 +60,8 @@ if args.float:
 else:
     DETECTOR_MODEL_PATH = f'face_detection_front_128_full_integer_quant.tflite'
     LANDMARK_MODEL_PATH = f'face_landmark_192_full_integer_quant_uint8.tflite'
+DETECTOR_MODEL_PATH = file_abs_path(__file__, DETECTOR_MODEL_PATH)
+LANDMARK_MODEL_PATH = file_abs_path(__file__, LANDMARK_MODEL_PATH)
 DETECTOR_REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/{DETECTION_MODEL_NAME}/'
 LANDMARK_REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/{LANDMARK_MODEL_NAME}/'
 
@@ -169,7 +173,7 @@ def recognize_from_image():
         else:
             preds_tf_lite[0] = get_real_tensor(detector, det_output_details, 1)   #1x896x16 regressors
             preds_tf_lite[1] = get_real_tensor(detector, det_output_details, 0)   #1x896x1 classificators
-        detections = fut.detector_postprocess(preds_tf_lite)
+        detections = fut.detector_postprocess(preds_tf_lite(__file__, "anchors.npy"))
 
         if detections[0].size != 0:
             imgs, affines, box = fut.estimator_preprocess(
@@ -279,7 +283,7 @@ def recognize_from_video():
         else:
             preds_tf_lite[0] = get_real_tensor(detector, det_output_details, 1)   #1x896x16 regressors
             preds_tf_lite[1] = get_real_tensor(detector, det_output_details, 0)   #1x896x1 classificators
-        detections = fut.detector_postprocess(preds_tf_lite)
+        detections = fut.detector_postprocess(preds_tf_lite, file_abs_path(__file__, "anchors.npy"))
 
         # Face landmark estimation
         if detections[0].size != 0:

--- a/face_recognition/facemesh/facemesh.py
+++ b/face_recognition/facemesh/facemesh.py
@@ -173,7 +173,7 @@ def recognize_from_image():
         else:
             preds_tf_lite[0] = get_real_tensor(detector, det_output_details, 1)   #1x896x16 regressors
             preds_tf_lite[1] = get_real_tensor(detector, det_output_details, 0)   #1x896x1 classificators
-        detections = fut.detector_postprocess(preds_tf_lite(__file__, "anchors.npy"))
+        detections = fut.detector_postprocess(preds_tf_lite, file_abs_path(__file__, "anchors.npy"))
 
         if detections[0].size != 0:
             imgs, affines, box = fut.estimator_preprocess(

--- a/face_recognition/facemesh/facemesh.py
+++ b/face_recognition/facemesh/facemesh.py
@@ -1,28 +1,34 @@
 import sys
+import os
 import time
+from logging import getLogger   # noqa: E402
 
 import cv2
 import numpy as np
 from scipy.special import expit
 
-import facemesh_utils as fut
 
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer  # noqa: E402
 from image_utils import load_image, preprocess_image  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from facemesh_const import FACEMESH_TESSELATION
+import facemesh_utils as fut
 
-from logging import getLogger   # noqa: E402
+
 logger = getLogger(__name__)
 
 

--- a/hand_recognition/blazehand/blazehand.py
+++ b/hand_recognition/blazehand/blazehand.py
@@ -7,8 +7,13 @@ import numpy as np
 import blazehand_utils as but
 
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer  # noqa: E402

--- a/hand_recognition/blazehand/blazehand.py
+++ b/hand_recognition/blazehand/blazehand.py
@@ -168,7 +168,7 @@ def recognize_from_image(detector, estimator):
         else:
             preds_tf_lite[0] = get_real_tensor(detector, det_output_details, 1)   #1x2944x18 regressors
             preds_tf_lite[1] = get_real_tensor(detector, det_output_details, 0)   #1x2944x1 classificators
-        detections = but.detector_postprocess(preds_tf_lite(__file__, "anchors.npy"))
+        detections = but.detector_postprocess(preds_tf_lite, file_abs_path(__file__, "anchors.npy"))
 
         # Hand landmark estimation
         presence = [0, 0]  # [left, right]

--- a/hand_recognition/blazehand/blazehand.py
+++ b/hand_recognition/blazehand/blazehand.py
@@ -9,9 +9,9 @@ import blazehand_utils as but
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/hand_recognition/blazehand/blazehand.py
+++ b/hand_recognition/blazehand/blazehand.py
@@ -1,26 +1,31 @@
+import os
 import sys
 import time
+from logging import getLogger   # noqa: E402
 
 import cv2
 import numpy as np
 
-import blazehand_utils as but
 
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer  # noqa: E402
 from image_utils import load_image, preprocess_image  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
+import blazehand_utils as but
 
-from logging import getLogger   # noqa: E402
+
 logger = getLogger(__name__)
 
 

--- a/image_classification/efficientnet_lite/efficientnet_lite.py
+++ b/image_classification/efficientnet_lite/efficientnet_lite.py
@@ -1,3 +1,4 @@
+import os
 import enum
 import sys
 import time
@@ -5,23 +6,26 @@ import time
 import cv2
 import numpy as np
 
-import efficientnet_lite_labels
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results, write_predictions  # noqa: E402
 import webcamera_utils  # noqa: E402
+import efficientnet_lite_labels
 
 
 # ======================

--- a/image_classification/efficientnet_lite/efficientnet_lite.py
+++ b/image_classification/efficientnet_lite/efficientnet_lite.py
@@ -8,8 +8,11 @@ import numpy as np
 import efficientnet_lite_labels
 
 # import original modules
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results, write_predictions  # noqa: E402
@@ -83,7 +86,7 @@ else:
             MODEL_NAME = 'efficientnetliteb0_quant'
         else:
             MODEL_NAME = 'efficientnetliteb0_quant_recalib'
-MODEL_PATH = f'{MODEL_NAME}.tflite'
+MODEL_PATH = file_abs_path(__file__, f'{MODEL_NAME}.tflite')
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/efficientnet_lite/'
 
 # ======================

--- a/image_classification/efficientnet_lite/efficientnet_lite.py
+++ b/image_classification/efficientnet_lite/efficientnet_lite.py
@@ -9,8 +9,13 @@ import efficientnet_lite_labels
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402

--- a/image_classification/efficientnet_lite/efficientnet_lite.py
+++ b/image_classification/efficientnet_lite/efficientnet_lite.py
@@ -11,9 +11,9 @@ import efficientnet_lite_labels
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/image_classification/googlenet/googlenet.py
+++ b/image_classification/googlenet/googlenet.py
@@ -1,28 +1,33 @@
-import time
+import os
 import sys
+import time
+from logging import getLogger   # noqa: E402
 
 import numpy as np
 import cv2
 
-import googlenet_labels
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results  # noqa: E402
 import webcamera_utils  # noqa: E402
+import googlenet_labels
 
-from logging import getLogger   # noqa: E402
+
 logger = getLogger(__name__)
 
 

--- a/image_classification/googlenet/googlenet.py
+++ b/image_classification/googlenet/googlenet.py
@@ -10,9 +10,9 @@ import googlenet_labels
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/image_classification/googlenet/googlenet.py
+++ b/image_classification/googlenet/googlenet.py
@@ -7,14 +7,16 @@ import cv2
 import googlenet_labels
 
 # import original modules
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, delegate_obj  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results  # noqa: E402
 import webcamera_utils  # noqa: E402
 
-# logger
 from logging import getLogger   # noqa: E402
 logger = getLogger(__name__)
 
@@ -51,7 +53,7 @@ if args.float:
     MODEL_NAME = 'googlenet_float32'
 else:
     MODEL_NAME = 'googlenet_quant_recalib'
-MODEL_PATH = f'{MODEL_NAME}.tflite'
+MODEL_PATH = file_abs_path(__file__, f'{MODEL_NAME}.tflite')
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/googlenet/'
 
 

--- a/image_classification/googlenet/googlenet.py
+++ b/image_classification/googlenet/googlenet.py
@@ -8,8 +8,13 @@ import googlenet_labels
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402

--- a/image_classification/mobilenetv1/mobilenetv1.py
+++ b/image_classification/mobilenetv1/mobilenetv1.py
@@ -8,8 +8,13 @@ import mobilenetv1_labels
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402

--- a/image_classification/mobilenetv1/mobilenetv1.py
+++ b/image_classification/mobilenetv1/mobilenetv1.py
@@ -10,9 +10,9 @@ import mobilenetv1_labels
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/image_classification/mobilenetv1/mobilenetv1.py
+++ b/image_classification/mobilenetv1/mobilenetv1.py
@@ -1,26 +1,30 @@
+import os
 import sys
 import time
 
 import cv2
 import numpy as np
 
-import mobilenetv1_labels
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results, write_predictions  # noqa: E402
 import webcamera_utils  # noqa: E402
+import mobilenetv1_labels
 
 
 # ======================

--- a/image_classification/mobilenetv1/mobilenetv1.py
+++ b/image_classification/mobilenetv1/mobilenetv1.py
@@ -7,8 +7,11 @@ import numpy as np
 import mobilenetv1_labels
 
 # import original modules
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results, write_predictions  # noqa: E402
@@ -71,7 +74,7 @@ else:
         MODEL_NAME = 'mobilenetv1_quant'
     else:
         MODEL_NAME = 'mobilenetv1_quant_recalib'
-MODEL_PATH = f'{MODEL_NAME}.tflite'
+MODEL_PATH = file_abs_path(__file__, f'{MODEL_NAME}.tflite')
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/mobilenetv1/'
 
 

--- a/image_classification/mobilenetv2/mobilenetv2.py
+++ b/image_classification/mobilenetv2/mobilenetv2.py
@@ -10,9 +10,9 @@ import mobilenetv2_labels
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/image_classification/mobilenetv2/mobilenetv2.py
+++ b/image_classification/mobilenetv2/mobilenetv2.py
@@ -8,8 +8,13 @@ import mobilenetv2_labels
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402

--- a/image_classification/mobilenetv2/mobilenetv2.py
+++ b/image_classification/mobilenetv2/mobilenetv2.py
@@ -7,8 +7,11 @@ import numpy as np
 import mobilenetv2_labels
 
 # import original modules
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results, write_predictions  # noqa: E402
@@ -71,7 +74,7 @@ else:
         MODEL_NAME = 'mobilenetv2_quant'
     else:
         MODEL_NAME = 'mobilenetv2_quant_recalib'
-MODEL_PATH = f'{MODEL_NAME}.tflite'
+MODEL_PATH = file_abs_path(__file__, f'{MODEL_NAME}.tflite')
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/mobilenetv2/'
 
 

--- a/image_classification/mobilenetv2/mobilenetv2.py
+++ b/image_classification/mobilenetv2/mobilenetv2.py
@@ -1,26 +1,30 @@
+import os
 import sys
 import time
 
 import cv2
 import numpy as np
 
-import mobilenetv2_labels
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results, write_predictions  # noqa: E402
 import webcamera_utils  # noqa: E402
+import mobilenetv2_labels
 
 
 # ======================

--- a/image_classification/resnet50/resnet50.py
+++ b/image_classification/resnet50/resnet50.py
@@ -11,9 +11,9 @@ import resnet50_labels
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/image_classification/resnet50/resnet50.py
+++ b/image_classification/resnet50/resnet50.py
@@ -9,8 +9,13 @@ import resnet50_labels
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402

--- a/image_classification/resnet50/resnet50.py
+++ b/image_classification/resnet50/resnet50.py
@@ -8,8 +8,11 @@ import numpy as np
 import resnet50_labels
 
 # import original modules
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results, write_predictions  # noqa: E402
@@ -72,7 +75,7 @@ else:
         MODEL_NAME = 'resnet50_quant'
     else:
         MODEL_NAME = 'resnet50_quant_recalib'
-MODEL_PATH = f'{MODEL_NAME}.tflite'
+MODEL_PATH = file_abs_path(__file__, f'{MODEL_NAME}.tflite')
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/resnet50/'
 
 

--- a/image_classification/resnet50/resnet50.py
+++ b/image_classification/resnet50/resnet50.py
@@ -1,27 +1,31 @@
 import enum
+import os
 import sys
 import time
 
 import cv2
 import numpy as np
 
-import resnet50_labels
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results, write_predictions  # noqa: E402
 import webcamera_utils  # noqa: E402
+import resnet50_labels
 
 
 # ======================

--- a/image_classification/squeezenet/squeezenet.py
+++ b/image_classification/squeezenet/squeezenet.py
@@ -1,26 +1,30 @@
+import os
 import sys
 import time
 
 import cv2
 import numpy as np
 
-import squeezenet_labels
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results  # noqa: E402
 import webcamera_utils  # noqa: E402
+import squeezenet_labels
 
 
 # ======================

--- a/image_classification/squeezenet/squeezenet.py
+++ b/image_classification/squeezenet/squeezenet.py
@@ -8,8 +8,13 @@ import squeezenet_labels
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402

--- a/image_classification/squeezenet/squeezenet.py
+++ b/image_classification/squeezenet/squeezenet.py
@@ -7,8 +7,11 @@ import numpy as np
 import squeezenet_labels
 
 # import original modules
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, delegate_obj  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results  # noqa: E402
@@ -50,7 +53,7 @@ if args.float:
     MODEL_NAME = 'squeezenet_float'
 else:
     MODEL_NAME = 'squeezenet_quant'
-MODEL_PATH = f'{MODEL_NAME}.tflite'
+MODEL_PATH = file_abs_path(__file__, f'{MODEL_NAME}.tflite')
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/squeezenet/'
 
 

--- a/image_classification/squeezenet/squeezenet.py
+++ b/image_classification/squeezenet/squeezenet.py
@@ -10,9 +10,9 @@ import squeezenet_labels
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/image_classification/vgg16/vgg16.py
+++ b/image_classification/vgg16/vgg16.py
@@ -7,14 +7,16 @@ import cv2
 import vgg16_labels
 
 # import original modules
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, delegate_obj  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results  # noqa: E402
 import webcamera_utils  # noqa: E402
 
-# logger
 from logging import getLogger   # noqa: E402
 logger = getLogger(__name__)
 
@@ -48,7 +50,7 @@ if args.float:
     MODEL_NAME = 'vgg16_pytorch_float32'
 else:
     MODEL_NAME = 'vgg16_pytorch_quant_recalib'
-MODEL_PATH = f'{MODEL_NAME}.tflite'
+MODEL_PATH = file_abs_path(__file__, f'{MODEL_NAME}.tflite')
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/vgg16/'
 
 # ======================

--- a/image_classification/vgg16/vgg16.py
+++ b/image_classification/vgg16/vgg16.py
@@ -1,28 +1,33 @@
+import os
 import sys
 import time
+from logging import getLogger   # noqa: E402
 
 import numpy as np
 import cv2
 
-import vgg16_labels
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from classifier_utils import plot_results, print_results  # noqa: E402
 import webcamera_utils  # noqa: E402
+import vgg16_labels
 
-from logging import getLogger   # noqa: E402
+
 logger = getLogger(__name__)
 
 

--- a/image_classification/vgg16/vgg16.py
+++ b/image_classification/vgg16/vgg16.py
@@ -10,9 +10,9 @@ import vgg16_labels
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/image_classification/vgg16/vgg16.py
+++ b/image_classification/vgg16/vgg16.py
@@ -8,8 +8,13 @@ import vgg16_labels
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402

--- a/image_classification/vgg16/vgg16_verify_tensors.py
+++ b/image_classification/vgg16/vgg16_verify_tensors.py
@@ -7,8 +7,13 @@ import hashlib
 import sys
 
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from model_utils import format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import normalize_image

--- a/image_classification/vgg16/vgg16_verify_tensors.py
+++ b/image_classification/vgg16/vgg16_verify_tensors.py
@@ -6,7 +6,10 @@ import cv2
 import hashlib
 import sys
 
-sys.path.append('../../util')
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
 from model_utils import format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import normalize_image
 

--- a/image_classification/vgg16/vgg16_verify_tensors.py
+++ b/image_classification/vgg16/vgg16_verify_tensors.py
@@ -9,9 +9,9 @@ import sys
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/image_classification/vgg16/vgg16_verify_tensors.py
+++ b/image_classification/vgg16/vgg16_verify_tensors.py
@@ -1,22 +1,30 @@
 # int8とfloatの誤差を比較する
 
+import os
+import sys
+
 import ailia_tflite
 import numpy as np
 import cv2
 import hashlib
-import sys
 
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from model_utils import format_input_tensor, get_output_tensor  # noqa: E402
 from image_utils import normalize_image
+
 
 def predict_tflite(tflite_path, input_data):
     # ailiaでtfliteファイルを読み込み

--- a/image_segmentation/deeplabv3plus/deeplabv3plus.py
+++ b/image_segmentation/deeplabv3plus/deeplabv3plus.py
@@ -10,9 +10,9 @@ from deeplab_utils import *
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/image_segmentation/deeplabv3plus/deeplabv3plus.py
+++ b/image_segmentation/deeplabv3plus/deeplabv3plus.py
@@ -8,8 +8,13 @@ from deeplab_utils import *
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor  # noqa: E402

--- a/image_segmentation/deeplabv3plus/deeplabv3plus.py
+++ b/image_segmentation/deeplabv3plus/deeplabv3plus.py
@@ -7,14 +7,15 @@ import numpy as np
 from deeplab_utils import *
 
 # import original modules
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
-from classifier_utils import plot_results, print_results  # noqa: E402
 import webcamera_utils  # noqa: E402
 
-# logger
 from logging import getLogger   # noqa: E402
 logger = getLogger(__name__)
 
@@ -54,7 +55,7 @@ if args.float:
     MODEL_NAME = 'deeplab_v3_plus_mnv2_decoder_256'
 else:
     MODEL_NAME = 'deeplab_v3_plus_mnv2_decoder_256_integer_quant'
-MODEL_PATH = f'{MODEL_NAME}.tflite'
+MODEL_PATH = file_abs_path(__file__, f'{MODEL_NAME}.tflite')
 REMOTE_PATH = 'https://storage.googleapis.com/ailia-models-tflite/deeplabv3plus/'
 
 

--- a/image_segmentation/deeplabv3plus/deeplabv3plus.py
+++ b/image_segmentation/deeplabv3plus/deeplabv3plus.py
@@ -1,27 +1,32 @@
+import os
 import sys
 import time
 
 import cv2
 import numpy as np
+from logging import getLogger   # noqa: E402
 
-from deeplab_utils import *
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor  # noqa: E402
 from image_utils import load_image  # noqa: E402
 import webcamera_utils  # noqa: E402
+from deeplab_utils import *
 
-from logging import getLogger   # noqa: E402
+
 logger = getLogger(__name__)
 
 

--- a/image_segmentation/hrnet_segmentation/hrnet_segmentation.py
+++ b/image_segmentation/hrnet_segmentation/hrnet_segmentation.py
@@ -7,8 +7,13 @@ from hrnet_utils import smooth_output, save_pred, gen_preds_img_np
 
 
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor  # noqa: E402

--- a/image_segmentation/hrnet_segmentation/hrnet_segmentation.py
+++ b/image_segmentation/hrnet_segmentation/hrnet_segmentation.py
@@ -6,8 +6,11 @@ import numpy as np
 from hrnet_utils import smooth_output, save_pred, gen_preds_img_np
 
 
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor  # noqa: E402
 from image_utils import load_image, preprocess_image  # noqa: E402
 import webcamera_utils  # noqa: E402
@@ -59,7 +62,7 @@ else:
     MODEL_NAME = args.arch + "_integer_quant"
 
 
-MODEL_PATH = f'{MODEL_NAME}.tflite'
+MODEL_PATH = file_abs_path(__file__, f'{MODEL_NAME}.tflite')
 REMOTE_PATH = 'https://storage.googleapis.com/ailia-models-tflite/hrnet/'
 
 

--- a/image_segmentation/hrnet_segmentation/hrnet_segmentation.py
+++ b/image_segmentation/hrnet_segmentation/hrnet_segmentation.py
@@ -9,9 +9,9 @@ from hrnet_utils import smooth_output, save_pred, gen_preds_img_np
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/image_segmentation/hrnet_segmentation/hrnet_segmentation.py
+++ b/image_segmentation/hrnet_segmentation/hrnet_segmentation.py
@@ -1,26 +1,32 @@
+import os
 import sys
 import time
+from logging import getLogger
 
 import cv2
 import numpy as np
-from hrnet_utils import smooth_output, save_pred, gen_preds_img_np
 
 
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor  # noqa: E402
 from image_utils import load_image, preprocess_image  # noqa: E402
 import webcamera_utils  # noqa: E402
+from hrnet_utils import smooth_output, save_pred, gen_preds_img_np
 
-from logging import getLogger
+
 logger = getLogger(__name__)
 
 

--- a/launcher.py
+++ b/launcher.py
@@ -9,7 +9,20 @@ import subprocess
 # Arguemnt Parser Config
 # ======================
 
-sys.path.append('./util')
+
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import get_base_parser, update_parser
 
 parser = get_base_parser(

--- a/object_detection/efficientdet_lite/efficientdet_lite.py
+++ b/object_detection/efficientdet_lite/efficientdet_lite.py
@@ -7,8 +7,13 @@ import cv2
 import numpy as np
 
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer  # noqa: E402

--- a/object_detection/efficientdet_lite/efficientdet_lite.py
+++ b/object_detection/efficientdet_lite/efficientdet_lite.py
@@ -1,26 +1,33 @@
-import colorsys
+import os
 import sys
+import colorsys
 import random
 import time
+from logging import getLogger   # noqa: E402
 
 import cv2
 import numpy as np
 
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer  # noqa: E402
 from image_utils import load_image, preprocess_image  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 
-from logging import getLogger   # noqa: E402
+
 logger = getLogger(__name__)
 
 

--- a/object_detection/efficientdet_lite/efficientdet_lite.py
+++ b/object_detection/efficientdet_lite/efficientdet_lite.py
@@ -6,14 +6,15 @@ import time
 import cv2
 import numpy as np
 
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, delegate_obj  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer  # noqa: E402
 from image_utils import load_image, preprocess_image  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
-from nms_utils import nms
 
-# logger
 from logging import getLogger   # noqa: E402
 logger = getLogger(__name__)
 
@@ -95,6 +96,7 @@ elif args.model == 'automl':
         MODEL_PATH = f'efficientdet-lite0_integer_quant_automl.tflite'
     DETECTION_SIZE = 320
 
+MODEL_PATH = file_abs_path(__file__, MODEL_PATH)
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/{MODEL_NAME}/'
 
 
@@ -358,9 +360,7 @@ def recognize_from_video():
 
 def main():
     # model files check and download
-    check_and_download_models(
-        MODEL_PATH, REMOTE_PATH
-    )
+    check_and_download_models(MODEL_PATH, REMOTE_PATH)
 
     if args.video is not None:
         # video mode

--- a/object_detection/efficientdet_lite/efficientdet_lite.py
+++ b/object_detection/efficientdet_lite/efficientdet_lite.py
@@ -9,9 +9,9 @@ import numpy as np
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/object_detection/mobilenetssd/mobilenetv2ssdlite.py
+++ b/object_detection/mobilenetssd/mobilenetv2ssdlite.py
@@ -1,25 +1,29 @@
+import os
 import sys
 import time
 
 import cv2
 
-import mobilenetv2ssdlite_utils as mut
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from detector_utils import plot_results  # noqa: E402
 import webcamera_utils  # noqa: E402
+import mobilenetv2ssdlite_utils as mut
 
 
 # ======================

--- a/object_detection/mobilenetssd/mobilenetv2ssdlite.py
+++ b/object_detection/mobilenetssd/mobilenetv2ssdlite.py
@@ -7,8 +7,13 @@ import mobilenetv2ssdlite_utils as mut
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402

--- a/object_detection/mobilenetssd/mobilenetv2ssdlite.py
+++ b/object_detection/mobilenetssd/mobilenetv2ssdlite.py
@@ -6,8 +6,11 @@ import cv2
 import mobilenetv2ssdlite_utils as mut
 
 # import original modules
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, delegate_obj  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from detector_utils import plot_results  # noqa: E402
@@ -38,7 +41,7 @@ else:
 # Parameters 2
 # ======================
 MODEL_NAME = 'ssdlite_mobilenet_v2_coco_300_integer_quant_with_postprocess'
-MODEL_PATH = f'{MODEL_NAME}.tflite'
+MODEL_PATH = file_abs_path(__file__, f'{MODEL_NAME}.tflite')
 REMOTE_PATH = 'https://storage.googleapis.com/ailia-models-tflite/mobilenetssd/'
 
 

--- a/object_detection/mobilenetssd/mobilenetv2ssdlite.py
+++ b/object_detection/mobilenetssd/mobilenetv2ssdlite.py
@@ -9,9 +9,9 @@ import mobilenetv2ssdlite_utils as mut
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/object_detection/yolov3-tiny/yolov3-tiny.py
+++ b/object_detection/yolov3-tiny/yolov3-tiny.py
@@ -85,7 +85,11 @@ if args.shape:
 # Parameters 2
 # ======================
 MODEL_NAME = 'yolov3-tiny'
-MODEL_PATH = file_abs_path(__file__, f'{MODEL_NAME}-416{"" if args.float else "_full_integer_quant"}.tflite')
+if args.float:
+    MODEL_PATH = f'{MODEL_NAME}-416.tflite'
+else:
+    MODEL_PATH = f'{MODEL_NAME}-416_full_integer_quant.tflite'
+MODEL_PATH = file_abs_path(__file__, MODEL_PATH)
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/{MODEL_NAME}/'
 
 

--- a/object_detection/yolov3-tiny/yolov3-tiny.py
+++ b/object_detection/yolov3-tiny/yolov3-tiny.py
@@ -7,8 +7,13 @@ import cv2
 import numpy as np
 
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer  # noqa: E402

--- a/object_detection/yolov3-tiny/yolov3-tiny.py
+++ b/object_detection/yolov3-tiny/yolov3-tiny.py
@@ -1,20 +1,27 @@
-import colorsys
+import os
 import sys
+import colorsys
 import random
 import time
+from logging import getLogger   # noqa: E402
 
 import cv2
 import numpy as np
 
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer  # noqa: E402
 from image_utils import load_image, preprocess_image  # noqa: E402
@@ -22,7 +29,7 @@ from model_utils import check_and_download_models  # noqa: E402
 from nms_utils import nms
 from detector_utils import write_predictions
 
-from logging import getLogger   # noqa: E402
+
 logger = getLogger(__name__)
 
 

--- a/object_detection/yolov3-tiny/yolov3-tiny.py
+++ b/object_detection/yolov3-tiny/yolov3-tiny.py
@@ -6,15 +6,17 @@ import time
 import cv2
 import numpy as np
 
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from webcamera_utils import get_capture, get_writer  # noqa: E402
 from image_utils import load_image, preprocess_image  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from nms_utils import nms
-from detector_utils import plot_results, write_predictions
+from detector_utils import write_predictions
 
-# logger
 from logging import getLogger   # noqa: E402
 logger = getLogger(__name__)
 
@@ -78,10 +80,7 @@ if args.shape:
 # Parameters 2
 # ======================
 MODEL_NAME = 'yolov3-tiny'
-if args.float:
-    MODEL_PATH = f'yolov3-tiny-416.tflite'
-else:
-    MODEL_PATH = f'yolov3-tiny-416_full_integer_quant.tflite'
+MODEL_PATH = file_abs_path(__file__, f'{MODEL_NAME}-416{"" if args.float else "_full_integer_quant"}.tflite')
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/{MODEL_NAME}/'
 
 
@@ -333,9 +332,7 @@ def recognize_from_video():
 
 def main():
     # model files check and download
-    check_and_download_models(
-        MODEL_PATH, REMOTE_PATH
-    )
+    check_and_download_models(MODEL_PATH, REMOTE_PATH)
 
     if args.video is not None:
         # video mode

--- a/object_detection/yolov3-tiny/yolov3-tiny.py
+++ b/object_detection/yolov3-tiny/yolov3-tiny.py
@@ -9,9 +9,9 @@ import numpy as np
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/object_detection/yolox/yolox.py
+++ b/object_detection/yolox/yolox.py
@@ -9,14 +9,15 @@ from yolox_utils import preproc as preprocess
 from yolox_utils import postprocess, filter_predictions
 
 # import original modules
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath, delegate_obj
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj
 from model_utils import check_and_download_models, format_input_tensor, \
     get_output_tensor
 from detector_utils import plot_results, write_predictions
 import webcamera_utils
 
-# logger
 from logging import getLogger
 
 logger = getLogger(__name__)
@@ -106,7 +107,7 @@ else:
     stem = f'{MODEL_NAME}_full_integer_quant'
 if not args.normal:
     stem += '.opt'
-MODEL_PATH = f'{stem}.tflite'
+MODEL_PATH = file_abs_path(__file__, f'{stem}.tflite')
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/yolox/'
 
 HEIGHT = MODEL_PARAMS[MODEL_NAME]['input_shape'][0]

--- a/object_detection/yolox/yolox.py
+++ b/object_detection/yolox/yolox.py
@@ -9,8 +9,13 @@ from yolox_utils import preproc as preprocess
 from yolox_utils import postprocess, filter_predictions
 
 # import original modules
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj
 from model_utils import check_and_download_models, format_input_tensor, \

--- a/object_detection/yolox/yolox.py
+++ b/object_detection/yolox/yolox.py
@@ -1,29 +1,33 @@
-import numpy as np
-import time
 import os
 import sys
-import cv2
+import time
 import math
+from logging import getLogger
 
+import cv2
+import numpy as np
+
+
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
+from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj
+from model_utils import check_and_download_models, format_input_tensor, get_output_tensor
+from detector_utils import plot_results, write_predictions
+import webcamera_utils
 from yolox_utils import preproc as preprocess
 from yolox_utils import postprocess, filter_predictions
 
-# import original modules
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
-from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj
-from model_utils import check_and_download_models, format_input_tensor, \
-    get_output_tensor
-from detector_utils import plot_results, write_predictions
-import webcamera_utils
-
-from logging import getLogger
 
 logger = getLogger(__name__)
 

--- a/object_detection/yolox/yolox.py
+++ b/object_detection/yolox/yolox.py
@@ -11,9 +11,9 @@ from yolox_utils import postprocess, filter_predictions
 # import original modules
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/pose_estimation/pose_resnet/pose_resnet.py
+++ b/pose_estimation/pose_resnet/pose_resnet.py
@@ -8,8 +8,13 @@ import const
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402

--- a/pose_estimation/pose_resnet/pose_resnet.py
+++ b/pose_estimation/pose_resnet/pose_resnet.py
@@ -7,8 +7,11 @@ import cv2
 import const
 
 # import original modules
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from image_utils import load_image as load_image_img, preprocess_image  # noqa: E402
 from detector_utils import load_image as load_image_det  # noqa: E402
@@ -16,7 +19,6 @@ from nms_utils import nms # noqa: E402
 import webcamera_utils  # noqa: E402
 from pose_resnet_util import compute, keep_aspect  # noqa: E402
 
-# logger
 from logging import getLogger   # noqa: E402
 logger = getLogger(__name__)
 
@@ -81,14 +83,14 @@ if args.float:
     POSE_MODEL_NAME = 'pose_resnet_50_256x192_float32'
 else:
     POSE_MODEL_NAME = 'pose_resnet_50_256x192_int8'
-POSE_MODEL_PATH = f'{POSE_MODEL_NAME}.tflite'
+POSE_MODEL_PATH = file_abs_path(__file__, f'{POSE_MODEL_NAME}.tflite')
 POSE_REMOTE_PATH = 'https://storage.googleapis.com/ailia-models-tflite/pose_resnet/'
 
 if args.float:
     DETECT_MODEL_NAME = 'yolov3-tiny-416'
 else:
     DETECT_MODEL_NAME = 'yolov3-tiny-416_full_integer_quant'
-DETECT_MODEL_PATH = f'{DETECT_MODEL_NAME}.tflite'
+DETECT_MODEL_PATH = file_abs_path(__file__, f'{DETECT_MODEL_NAME}.tflite')
 DETECT_REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/yolov3-tiny/'
 
 

--- a/pose_estimation/pose_resnet/pose_resnet.py
+++ b/pose_estimation/pose_resnet/pose_resnet.py
@@ -6,16 +6,20 @@ import cv2
 
 import const
 
-# import original modules
+
 import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath, delegate_obj  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from image_utils import load_image as load_image_img, preprocess_image  # noqa: E402

--- a/pose_estimation/pose_resnet/pose_resnet.py
+++ b/pose_estimation/pose_resnet/pose_resnet.py
@@ -10,9 +10,9 @@ import const
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/pose_estimation/pose_resnet/pose_resnet_util.py
+++ b/pose_estimation/pose_resnet/pose_resnet_util.py
@@ -1,22 +1,26 @@
+import os
 import sys
 import math
 
 import cv2
 import numpy as np
 
-import const
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from model_utils import format_input_tensor, get_output_tensor  # noqa: E402
+import const
 
 
 def transform_preds(coords, center, scale, output_size):

--- a/pose_estimation/pose_resnet/pose_resnet_util.py
+++ b/pose_estimation/pose_resnet/pose_resnet_util.py
@@ -7,7 +7,10 @@ import numpy as np
 import const
 
 # import original modules
-sys.path.append('../../util')
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
 from model_utils import format_input_tensor, get_output_tensor  # noqa: E402
 
 

--- a/pose_estimation/pose_resnet/pose_resnet_util.py
+++ b/pose_estimation/pose_resnet/pose_resnet_util.py
@@ -8,8 +8,13 @@ import const
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from model_utils import format_input_tensor, get_output_tensor  # noqa: E402
 

--- a/pose_estimation/pose_resnet/pose_resnet_util.py
+++ b/pose_estimation/pose_resnet/pose_resnet_util.py
@@ -10,9 +10,9 @@ import const
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/super_resolution/espcn/espcn.py
+++ b/super_resolution/espcn/espcn.py
@@ -8,9 +8,9 @@ import numpy as np
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/super_resolution/espcn/espcn.py
+++ b/super_resolution/espcn/espcn.py
@@ -6,8 +6,13 @@ import numpy as np
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402

--- a/super_resolution/espcn/espcn.py
+++ b/super_resolution/espcn/espcn.py
@@ -5,15 +5,15 @@ import cv2
 import numpy as np
 
 # import original modules
-sys.path.append('../../util')
-from utils import get_base_parser, update_parser, get_savepath  # noqa: E402
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
+from utils import file_abs_path, get_base_parser, update_parser, get_savepath  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
-from image_utils import load_image  # noqa: E402
-from classifier_utils import plot_results, print_results  # noqa: E402
 import webcamera_utils  # noqa: E402
 
 
-# logger
 from logging import getLogger   # noqa: E402
 logger = getLogger(__name__)
 
@@ -49,7 +49,7 @@ if args.float:
     MODEL_NAME = 'espcn'
 else:
     MODEL_NAME = 'espcn_quant'
-MODEL_PATH = f'{MODEL_NAME}.tflite'
+MODEL_PATH = file_abs_path(__file__, f'{MODEL_NAME}.tflite')
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/espcn/'
 
 

--- a/super_resolution/espcn/espcn.py
+++ b/super_resolution/espcn/espcn.py
@@ -1,25 +1,30 @@
+import os
 import sys
 import time
+from logging import getLogger   # noqa: E402
 
 import cv2
 import numpy as np
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
+
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
+
 from utils import file_abs_path, get_base_parser, update_parser, get_savepath  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 import webcamera_utils  # noqa: E402
 
 
-from logging import getLogger   # noqa: E402
 logger = getLogger(__name__)
 
 

--- a/super_resolution/srresnet/srresnet.py
+++ b/super_resolution/srresnet/srresnet.py
@@ -7,8 +7,13 @@ import numpy as np
 
 # import original modules
 import os
-es = os.path.abspath(__file__).split('/')
-util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+REPO_NAME = "ailia-models-tflite"
+path_elements = os.path.abspath(__file__).split('/')
+assert REPO_NAME in path_elements, """
+    It seems you renamed the repo,
+    please name it back to `ailia-models-tflite`,
+    or update the REPO_NAME varibale to reflect the change you did"""
+util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)
 from logging import getLogger  # noqa: E402
 

--- a/super_resolution/srresnet/srresnet.py
+++ b/super_resolution/srresnet/srresnet.py
@@ -1,26 +1,30 @@
 import os
 import sys
 import time
+from logging import getLogger  # noqa: E402
 
 import cv2
 import numpy as np
 
-# import original modules
-import os
-REPO_NAME = "ailia-models-tflite"
-path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, f"""
-    It seems you renamed the repo,
-    please name it back to `{REPO_NAME}`,
-    or update the REPO_NAME varibale to reflect the change you did"""
-util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
-sys.path.append(util_path)
-from logging import getLogger  # noqa: E402
+
+def find_and_append_util_path():
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    while current_dir != os.path.dirname(current_dir):
+        potential_util_path = os.path.join(current_dir, 'util')
+        if os.path.exists(potential_util_path):
+            sys.path.append(potential_util_path)
+            return
+        current_dir = os.path.dirname(current_dir)
+    raise FileNotFoundError("Couldn't find 'util' directory. Please ensure it's in the project directory structure.")
+
+find_and_append_util_path()
+
 
 import webcamera_utils  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
 from utils import file_abs_path, get_base_parser, get_savepath, update_parser, delegate_obj  # noqa: E402
+
 
 logger = getLogger(__name__)
 

--- a/super_resolution/srresnet/srresnet.py
+++ b/super_resolution/srresnet/srresnet.py
@@ -6,14 +6,16 @@ import cv2
 import numpy as np
 
 # import original modules
-sys.path.append('../../util')
-# logger
+import os
+es = os.path.abspath(__file__).split('/')
+util_path = os.path.join('/', *es[:es.index('ailia-models-tflite') + 1], 'util')
+sys.path.append(util_path)
 from logging import getLogger  # noqa: E402
 
 import webcamera_utils  # noqa: E402
 from image_utils import load_image  # noqa: E402
 from model_utils import check_and_download_models, format_input_tensor, get_output_tensor  # noqa: E402
-from utils import get_base_parser, get_savepath, update_parser, delegate_obj  # noqa: E402
+from utils import file_abs_path, get_base_parser, get_savepath, update_parser, delegate_obj  # noqa: E402
 
 logger = getLogger(__name__)
 
@@ -58,7 +60,7 @@ if args.float:
     MODEL_NAME = 'srresnet.opt_float32'
 else:
     MODEL_NAME = 'srresnet.opt_full_integer_quant'
-MODEL_PATH = f'{MODEL_NAME}.tflite'
+MODEL_PATH = file_abs_path(__file__, f'{MODEL_NAME}.tflite')
 REMOTE_PATH = f'https://storage.googleapis.com/ailia-models-tflite/srresnet/'
 
 

--- a/super_resolution/srresnet/srresnet.py
+++ b/super_resolution/srresnet/srresnet.py
@@ -9,9 +9,9 @@ import numpy as np
 import os
 REPO_NAME = "ailia-models-tflite"
 path_elements = os.path.abspath(__file__).split('/')
-assert REPO_NAME in path_elements, """
+assert REPO_NAME in path_elements, f"""
     It seems you renamed the repo,
-    please name it back to `ailia-models-tflite`,
+    please name it back to `{REPO_NAME}`,
     or update the REPO_NAME varibale to reflect the change you did"""
 util_path = os.path.join('/', *path_elements[:path_elements.index(REPO_NAME) + 1], 'util')
 sys.path.append(util_path)

--- a/util/utils.py
+++ b/util/utils.py
@@ -251,3 +251,12 @@ def delegate_obj(delegate_path):
         return None
     else:
         return [ailia_tflite.load_delegate(delegate_path)]
+
+
+def file_abs_path(calling__file__: str, file_name: str) -> str:
+    '''
+    Gives the absolute path of the `file_name` (assumed to be in the same dir. as the calling functions' file)
+    @param calling__file__: this should be `__file__` from where this function is called
+    @param file_name: name or path of the file that we want to extract the absolute path of
+    '''
+    return os.path.join(os.path.dirname(os.path.abspath(calling__file__)), os.path.basename(file_name))


### PR DESCRIPTION
## Brief:

This change allows for running any model from any location in the system. Since, due to the paths being hardcoded (example: `sys.path.append("../../util")`), you need to be in the directory containing the model in order to run it.

## Motive:

I discovered this great project 3 days ago, and upon wanting to play around with the models (hobby project), I encountered an import issue of the `utils`, given that I wanted to run various models from the same location (habit of writing long paths in the terminal instead of relocating).

I originally didn't intend to open a PR, since I only did the changes for my own sake. But, I think that these changes might be useful to people using this repo.

## About the changes:

The changes rely on the user cloning the repo, not changing its name. But, in case such a thing happens, I added an `assert` to inform them nicely of what needs to be done:

![ailia-assert](https://github.com/user-attachments/assets/efa79bb3-f7c8-4688-9398-78f27c699ccd)

The changes are seemingly big, but in reality I only added a single `utility function`, and a little snippet of code that finds the `utils path`, but since they're used in all models, the effect is amplified.

## Commits:

I usually squash my changes, but I didn't find a contribution guide in the repo, so I decided to leave my changes as is, and give you the ability to `squash` if you happen to decide to accept this PR.

Please let me know if there is anything I can do to make this PR accepted.